### PR TITLE
Add a defib, beaker, large beaker, and dropper to Holestation's medical.

### DIFF
--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -7802,13 +7802,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "Pl" = (
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 3;
-	pixel_y = 4
-	},
 /obj/structure/table,
 /obj/structure/railing{
 	dir = 10
+	},
+/obj/item/defibrillator/loaded,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay)
@@ -9936,7 +9937,15 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
-/obj/item/stack/sheet/mineral/plasma,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 10
+	},
 /turf/open/floor/iron,
 /area/medical/medbay)
 "Zi" = (


### PR DESCRIPTION
## About The Pull Request

Adds a defib, beaker, large beaker, and dropper to Holestation's medical, per the title.

## Why It's Good For The Game

Players on Holestation will now have a way of reviving people that doesn't involve using a baton. Additionally, chemists won't have as much headaches making chems now that they have beakers.

## Changelog

:cl:
add: Added defibrillator to Holestation's medical.
add: Added beaker, large beaker, and dropper to Holestation's chemistry.
/:cl:
